### PR TITLE
Alarm Capability

### DIFF
--- a/index.html
+++ b/index.html
@@ -115,6 +115,7 @@
         <li><a href="#PushButton">PushButton</a></li>
         <li><a href="#Camera">Camera</a></li>
         <li><a href="#VideoCamera">VideoCamera</a></li>
+        <li><a href="#Alarm">Alarm</a></li>
       </ul>
       <li><strong><a href="#properties">Properties</a></strong></li>
       <ul>
@@ -135,6 +136,7 @@
         <li><a href="#TemperatureProperty">TemperatureProperty</a></li>
         <li><a href="#ImageProperty">ImageProperty</a></li>
         <li><a href="#VideoProperty">VideoProperty</a></li>
+        <li><a href="#AlarmProperty">AlarmProperty</a></li>
       </ul>
       <li><strong><a href="#actions">Actions</a></strong></li>
       <ul>
@@ -147,6 +149,7 @@
         <li><a href="#PressedEvent">PressedEvent</a></li>
         <li><a href="#DoublePressedEvent">DoublePressedEvent</a></li>
         <li><a href="#LongPressedEvent">LongPressedEvent</a></li>
+        <li><a href="#AlarmEvent">AlarmEvent</a></li>
       </ul>
     </ul>
     <section id="capabilities">
@@ -579,6 +582,36 @@
         <h3>Events</h3>
         <p>None.</p>
       </section>
+      <section id="Alarm">
+        <h2>Alarm</h2>
+        <p>A device which alerts the user with an audio or visual indicator. E.g. A smoke alarm, CO alarm, burglar alarm or alarm clock.</p>
+        <h3>Properties</h3>
+          <table>
+            <tr>
+              <th>Type</th>
+              <th>Read-Only</th>
+              <th>Required</th>
+            </tr>
+            <tr>
+              <td><a href="#AlarmProperty">AlarmProperty</a></td>
+              <td>Yes</td>
+              <td>Yes</td>
+            </tr>
+          </table>
+        <h3>Actions</h3>
+        <p>None.</p>
+        <h3>Events</h3>
+        <table>
+          <tr>
+            <th>Type</th>
+            <th>Required</th>
+          </tr>
+          <tr>
+            <td><a href="#AlarmEvent">AlarmEvent</a></td>
+            <td>Yes</td>
+          </tr>
+        </table>
+      </section>
     </section>
     <section id="properties">
       <h1>Properties</h1>
@@ -800,6 +833,15 @@
         </table>
         <p><strong>Note:</strong> The primitive <code>type</code> of a <code>VideoProperty</code> is <code>null</code> or <code>undefined</code> (omitted), but it must provide a <code>mediaType</code> in one or more <a href="https://iot.mozilla.org/wot/#link-object">link relations</a> which link to binary representations of the video property resource.</p>
       </section>
+      <section id="AlarmProperty">
+        <h2>AlarmProperty</h2>
+        <table>
+          <tr>
+            <th>type</th>
+            <td>boolean</td>
+          </tr>
+        </table>
+      </section>
     </section>
     <section id="actions">
       <h1>Actions</h1>
@@ -869,6 +911,10 @@
       <section id="LongPressedEvent">
         <h2>LongPressedEvent</h2>
         <p>Indicates a button has been long-pressed.</p>
+      </section>
+      <section id="AlarmEvent">
+        <h2>AlarmEvent</h2>
+        <p>Indicates an alarm has been triggered.</p>
       </section>
     </section>
   </body>


### PR DESCRIPTION
Closes #31.

I have shied away from the enum because the three states (ok, warning and emergency) felt a bit arbitrary, but you may disagree.

Looking at the Zigbee specification I note there are many other options a "warning device" using the IAS WD cluster can specify, including:
* Warning mode
  * 0 - Stop
  * 1 - Burglar
  * 2 - Fire
  * 3 - Emergency
  * 4 - Police panic
  * 5 - Fire panic
  * 6 - Emergency (medical) panic
* Strobe
* Siren level
* Warning duration
* Strobe duty
* Strobe duty cycle
* Strobe level

For the time being I have opted for the simplest possible solution with a single boolean `AlarmProperty`. Is this enough to get started with? Perhaps we could extend this in future.

To be honest I'm struggling to justify the need for the `AlarmEvent` in addition to the `AlarmProperty`, though it feels like a natural use of an event.