### PR TITLE
Add ColorSensor Capability

### DIFF
--- a/index.html
+++ b/index.html
@@ -109,6 +109,7 @@
         <li><a href="#BinarySensor">BinarySensor</a></li>
         <li><a href="#Camera">Camera</a></li>  
         <li><a href="#ColorControl">ColorControl</a></li>      
+        <li><a href="#ColorSensor">ColorSensor</a></li>
         <li><a href="#DoorSensor">DoorSensor</a></li>
         <li><a href="#EnergyMonitor">EnergyMonitor</a></li>
         <li><a href="#LeakSensor">LeakSensor</a>
@@ -262,6 +263,27 @@
         <h3>Events</h3>
         <p>None.</p>
       </section>      
+      <section id="ColorSensor">
+        <h2>ColorSensor</h2>
+        <p>A device which detects a color.</p>
+        <h3>Properties</h3>
+          <table>
+            <tr>
+              <th>Type</th>
+              <th>Read-Only</th>
+              <th>Required</th>
+            </tr>
+            <tr>
+              <td><a href="#ColorProperty">ColorProperty</a></td>
+              <td>Yes</td>
+              <td>Yes</td>
+            </tr>
+          </table>
+        <h3>Actions</h3>
+        <p>None.</p>
+        <h3>Events</h3>
+        <p>None.</p>
+      </section>
       <section id="DoorSensor">
         <h2>DoorSensor</h2>
         <p>A device which detects whether a door or window is open or closed.</p>


### PR DESCRIPTION
I have used color sensors lately, to display it on dashboard
I had to reuse a ColorController and set property as read only,
even if this work this can be misleading,
because nothing is controllable then.

This makes me think that RO and WO caps could be generalized as:
{type}Sensor and {type}Actuator

Change-Id: Id64f25acdbb45cb5242e6cd0ff00b31aefe84cee
Relate-to: https://www.slideshare.net/rzrfreefr/wotxr20190320rzr
Signed-off-by: Philippe Coval <p.coval@samsung.com>